### PR TITLE
fix parsing of two multiplications sum (a*b+c*d)

### DIFF
--- a/src/syntax.pest
+++ b/src/syntax.pest
@@ -14,7 +14,7 @@ mulOp = _{ mul | div }
 
 // Expressions.
 addExprW = _{ addExpr | mulExprW }
-    addExpr = { term ~ addOp ~ addExprW }
+    addExpr = { mulExprW ~ addOp ~ addExprW }
 mulExprW = _{ mulExpr | term }
     mulExpr = { term ~ mulOp ~ mulExprW }
 term = _{ number | "(" ~ addExprW ~ ")" }


### PR DESCRIPTION
parsing the lhs term of addition expr fails when its a multiplication fixed syntax by expecting a mul. expr